### PR TITLE
Add support for `isOneOf` in input object types

### DIFF
--- a/.changeset/cyan-moose-fry.md
+++ b/.changeset/cyan-moose-fry.md
@@ -1,0 +1,6 @@
+---
+"@graphql-ts/extend": patch
+"@graphql-ts/schema": patch
+---
+
+Add support for `isOneOf` in input object types

--- a/packages/extend/src/index.ts
+++ b/packages/extend/src/index.ts
@@ -17,7 +17,6 @@ import {
   // in normal projects, you should import `g`
   graphql as g,
   ObjectType,
-  InputObjectType,
   Arg,
   InputType,
   EnumType,
@@ -46,6 +45,7 @@ import {
 } from "graphql";
 
 import * as wrap from "./wrap";
+import { InputObjectType } from "./input-object-type";
 
 export { wrap };
 
@@ -492,7 +492,7 @@ export type BaseSchemaMeta = {
    */
   inputObject(
     name: string
-  ): InputObjectType<{ [key: string]: Arg<InputType, boolean> }>;
+  ): InputObjectType<{ [key: string]: Arg<InputType, boolean> }, boolean>;
   /**
    * Gets an enum type from the existing GraphQL schema and wraps it in an
    * {@link EnumType}. If there is no enum type in the existing schema with the

--- a/packages/extend/src/input-object-type.ts
+++ b/packages/extend/src/input-object-type.ts
@@ -1,0 +1,16 @@
+// TODO: remove when a breaking change necessitates bumping the peer dep requirement of @graphql-ts/schema
+
+import type {
+  InputObjectType as _InputObjectType,
+  Arg,
+  InputType,
+} from "@graphql-ts/schema";
+
+/**
+ * This type exists purely for backwards compatibility reasons. You should use
+ * {@link _InputObjectType `InputObjectType`} instead.
+ */
+export type InputObjectType<
+  Fields extends { [key: string]: Arg<InputType> },
+  IsOneOf extends boolean
+> = Omit<_InputObjectType<Fields>, "isOneOf"> & { isOneOf: IsOneOf };

--- a/packages/extend/src/wrap.ts
+++ b/packages/extend/src/wrap.ts
@@ -12,7 +12,6 @@
 
 import {
   ObjectType,
-  InputObjectType,
   EnumType,
   EnumValue,
   Arg,
@@ -29,6 +28,7 @@ import {
   GraphQLObjectType,
   GraphQLUnionType,
 } from "graphql";
+import { InputObjectType } from "./input-object-type";
 
 /**
  * Wraps an existing {@link GraphQLObjectType} into a {@link ObjectType} so that
@@ -79,11 +79,12 @@ export function object(
  */
 export function inputObject(
   graphQLType: GraphQLInputObjectType
-): InputObjectType<{ [key: string]: Arg<InputType, boolean> }> {
+): InputObjectType<{ [key: string]: Arg<InputType, boolean> }, boolean> {
   return {
     kind: "input",
     __context: undefined as any,
     __fields: undefined as any,
+    isOneOf: graphQLType.isOneOf,
     graphQLType,
   };
 }

--- a/test-project/index.test-d.ts
+++ b/test-project/index.test-d.ts
@@ -1143,3 +1143,229 @@ function assertCompatible<A, _B extends A>() {}
     }),
   });
 }
+
+const someInputFields = {
+  a: g.arg({ type: g.String }),
+  b: g.arg({ type: g.String }),
+};
+
+{
+  const Something = g.inputObject({
+    name: "Something",
+    fields: someInputFields,
+    isOneOf: true,
+  });
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, true>>,
+    Invariant<typeof Something>
+  >();
+  g.field({
+    args: {
+      something: g.arg({ type: g.nonNull(Something) }),
+    },
+    type: g.String,
+    resolve(_, { something }) {
+      assertCompatible<
+        Invariant<
+          | {
+              readonly a: string;
+              readonly b?: undefined;
+            }
+          | {
+              readonly b: string;
+              readonly a?: undefined;
+            }
+        >,
+        Invariant<typeof something>
+      >();
+
+      return "";
+    },
+  });
+}
+
+{
+  const Something = g.inputObject({
+    name: "Something",
+    fields: someInputFields,
+    isOneOf: Math.random() > 0.5,
+  });
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, boolean>>,
+    Invariant<typeof Something>
+  >();
+  g.field({
+    args: {
+      something: g.arg({ type: g.nonNull(Something) }),
+    },
+    type: g.String,
+    resolve(_, { something }) {
+      assertCompatible<
+        Invariant<
+          | {
+              readonly a: string | null | undefined;
+              readonly b: string | null | undefined;
+            }
+          | {
+              readonly a: string;
+              readonly b?: undefined;
+            }
+          | {
+              readonly b: string;
+              readonly a?: undefined;
+            }
+        >,
+        Invariant<typeof something>
+      >();
+
+      return "";
+    },
+  });
+}
+
+{
+  const Something = g.inputObject({
+    name: "Something",
+    fields: someInputFields,
+  });
+
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, false>>,
+    Invariant<typeof Something>
+  >();
+
+  g.field({
+    args: {
+      something: g.arg({ type: g.nonNull(Something) }),
+    },
+    type: g.String,
+    resolve(_, { something }) {
+      assertCompatible<
+        Invariant<{
+          readonly a: string | null | undefined;
+          readonly b: string | null | undefined;
+        }>,
+        Invariant<typeof something>
+      >();
+
+      return "";
+    },
+  });
+}
+
+{
+  const Something = g.inputObject({
+    name: "Something",
+    fields: someInputFields,
+    isOneOf: false,
+  });
+
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, false>>,
+    Invariant<typeof Something>
+  >();
+}
+
+{
+  const Something = g.inputObject<typeof someInputFields>({
+    name: "Something",
+    fields: someInputFields,
+  });
+
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, false>>,
+    Invariant<typeof Something>
+  >();
+}
+
+{
+  g.inputObject<typeof someInputFields, true>(
+    // @ts-expect-error
+    {
+      name: "Something",
+      fields: someInputFields,
+    }
+  );
+}
+
+{
+  g.inputObject<typeof someInputFields, true>({
+    name: "Something",
+    fields: someInputFields,
+    // @ts-expect-error
+    isOneOf: false,
+  });
+}
+
+{
+  g.inputObject<typeof someInputFields, false>({
+    name: "Something",
+    fields: someInputFields,
+    // @ts-expect-error
+    isOneOf: true,
+  });
+}
+
+{
+  const Something = g.inputObject<typeof someInputFields, boolean>({
+    name: "Something",
+    fields: someInputFields,
+    isOneOf: true,
+  });
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, boolean>>,
+    Invariant<typeof Something>
+  >();
+}
+
+{
+  const Something = g.inputObject<typeof someInputFields, boolean>({
+    name: "Something",
+    fields: someInputFields,
+    isOneOf: false,
+  });
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, boolean>>,
+    Invariant<typeof Something>
+  >();
+}
+
+{
+  const Something = g.inputObject<typeof someInputFields, boolean>({
+    name: "Something",
+    fields: someInputFields,
+    isOneOf: Math.random() > 0.5,
+  });
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, boolean>>,
+    Invariant<typeof Something>
+  >();
+}
+
+{
+  g.inputObject<typeof someInputFields, boolean>(
+    // @ts-expect-error
+    {
+      name: "Something",
+      fields: someInputFields,
+    }
+  );
+}
+
+{
+  const Something = g.inputObject({
+    name: "Something",
+    fields: someInputFields,
+    isOneOf: undefined,
+  });
+  // arguably "bad" that it infers to boolean vs false but this makes no sense to write
+  // could be "fixed" by making inputObject do (true extends IsOneOf ? { isOneOf: IsOneOf } : unknown)
+  // instead of (true extends IsOneOf ? { isOneOf: unknown } : unknown)
+  // but idk, using unknown feels conceptually closer to the behavior i'm going for
+  // this would also be banned under exactOptionalPropertyTypes
+  // which again feels conceptually correct rather than banning when not using exactOptionalPropertyTypes
+  assertCompatible<
+    Invariant<g.InputObjectType<typeof someInputFields, boolean>>,
+    Invariant<typeof Something>
+  >();
+}


### PR DESCRIPTION
```ts
const MyInput = g.inputObject({
  name: "MyInput",
  fields: {
    a: g.arg({ type: g.String }),
    b: g.arg({ type: g.String }),
  },
  isOneOf: true,
});

g.field({
  type: g.String,
  args: {
    input: g.arg({ type: g.nonNull(MyInput) }),
  },
  resolve(_, { input }) {
    // `input` looks like this:
    type x =
      | { readonly a: string; readonly b?: undefined }
      | { readonly b: string; readonly a?: undefined };
    return "";
  },
});
```