### PR TITLE
Improve types that enforce correct fields are provided when `interfaces` are passed to `g.object`/`g.interface`

### DIFF
--- a/.changeset/silver-oranges-judge.md
+++ b/.changeset/silver-oranges-judge.md
@@ -1,0 +1,5 @@
+---
+"@graphql-ts/schema": patch
+---
+
+Improve types that enforce correct fields are provided when `interfaces` are passed to `g.object`/`g.interface`

--- a/.changeset/slow-seas-end.md
+++ b/.changeset/slow-seas-end.md
@@ -1,0 +1,5 @@
+---
+"@graphql-ts/schema": patch
+---
+
+Deprecate `InterfaceToInterfaceFields` and `InterfacesToOutputFields` types.

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -50,10 +50,8 @@ export type {
   InferValueFromOutputType,
   InterfaceField,
   InterfaceFieldFunc,
-  InterfaceToInterfaceFields,
   InterfaceType,
   InterfaceTypeFunc,
-  InterfacesToOutputFields,
   NullableOutputType,
   ObjectType,
   ObjectTypeFunc,
@@ -78,3 +76,7 @@ export type {
 } from "./api-without-context";
 export type { Type, NullableType } from "./type";
 export * from "./schema-api-alias";
+export type {
+  InterfaceToInterfaceFields,
+  InterfacesToOutputFields,
+} from "./output";


### PR DESCRIPTION
The main thing here is avoiding `UnionToIntersection` since that's generally a bad idea and we don't need it in this case by just avoiding creating the union that we want to intersect in the first place.