### PR TITLE
Easier context binding with instantiation expressions

### DIFF
--- a/.changeset/purple-beers-mate.md
+++ b/.changeset/purple-beers-mate.md
@@ -1,0 +1,35 @@
+---
+"@graphql-ts/schema": major
+---
+
+The `g` export exported from `@graphql-ts/schema` directly is now deprecated. Using `initG` is now the recommended way to use `@graphql-ts/schema` instead of the instance of `g` exported by `@graphql-ts/schema` or creating multiple files to setup `g` though using those is still possible.
+
+```ts
+import { GraphQLSchema } from "graphql";
+import { initG } from "@graphql-ts/schema";
+
+type Context = {
+  something: string;
+};
+
+const g = initG<Context>();
+type g<T> = initG<T>;
+
+const Query = g.object()({
+  name: "Query",
+  fields: {
+    something: g.field({
+      type: g.String,
+      resolve(_, __, context) {
+        return context.something;
+      },
+    }),
+  },
+});
+
+const schema = new GraphQLSchema({
+  query: Query,
+});
+```
+
+All types available at `g.*` like `g.ObjectType<Source>` can written instead like `g<typeof g.object<Source>>` or from types available from `@graphql-ts/schema` instead of being accessible directly on `g`.

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -6,16 +6,45 @@ constructing GraphQL Schemas while avoiding type-generation, [declaration mergin
 and [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html).
 
 ```ts
-import { g } from "@graphql-ts/schema";
+import { initG } from "@graphql-ts/schema";
 import { GraphQLSchema, graphql } from "graphql";
+
+type Context = {
+  loadPerson: (id: string) => Person;
+  loadFriends: (id: string) => Person[];
+};
+const g = initG<Context>();
+type g<T> = initG<T>;
+
+type Person = {
+  id: string;
+  name: string;
+};
+
+const Person: g<typeof g.object<Person>> = g.object<Person>()({
+  name: "Person",
+  fields: () => ({
+    id: g.field({ type: g.ID }),
+    name: g.field({ type: g.String }),
+    friends: g.field({
+      type: g.list(Person),
+      resolve(source, _, context) {
+        return context.loadFriends(source.id);
+      },
+    }),
+  }),
+});
 
 const Query = g.object()({
   name: "Query",
   fields: {
-    hello: g.field({
-      type: g.String,
-      resolve() {
-        return "Hello!";
+    person: g.field({
+      type: Person,
+      args: {
+        id: g.arg({ type: g.ID }),
+      },
+      resolve(_, args, context) {
+        return context.loadPerson(args.id);
       },
     }),
   },
@@ -25,13 +54,37 @@ const schema = new GraphQLSchema({
   query: Query,
 });
 
+const people = new Map<string, Person>([
+  ["1", { id: "1", name: "Alice" }],
+  ["2", { id: "2", name: "Bob" }],
+]);
+const friends = new Map<string, string[]>([
+  ["1", ["2"]],
+  ["2", ["1"]],
+]);
+
 graphql({
   source: `
-    query {
-      hello
-    }
-  `,
+      query {
+        person(id: "1") {
+          id
+          name
+          friends {
+            id
+            name
+          }
+        }
+      }
+    `,
   schema,
+  context: {
+    loadPerson: (id) => people.get(id),
+    loadFriends: (id) => {
+      return (friends.get(id) ?? [])
+        .map((id) => people.get(id))
+        .filter((person) => person !== undefined);
+    },
+  },
 }).then((result) => {
   console.log(result);
 });

--- a/packages/schema/src/api-with-context/api-with-context.js
+++ b/packages/schema/src/api-with-context/api-with-context.js
@@ -1,6 +1,4 @@
-import { initG } from "../output";
-
-const g = initG();
+import { g } from "@graphql-ts/schema";
 
 export const { field, fields, interfaceField, object, union } = g;
 

--- a/packages/schema/src/api-with-context/index.ts
+++ b/packages/schema/src/api-with-context/index.ts
@@ -1,8 +1,14 @@
+/**
+ * @module
+ * @deprecated This entrypoint should no longer be used. Use {@link initG}
+ *   instead.
+ */
+import { initG } from "@graphql-ts/schema";
 export {
   field,
   fields,
-  interface,
   interfaceField,
   object,
   union,
+  interface,
 } from "./api-with-context";

--- a/packages/schema/src/api-without-context/api-without-context.js
+++ b/packages/schema/src/api-without-context/api-without-context.js
@@ -1,6 +1,4 @@
-import { initG } from "../output";
-
-const g = initG();
+import { g } from "@graphql-ts/schema";
 
 export const {
   Boolean,

--- a/packages/schema/src/api-without-context/index.ts
+++ b/packages/schema/src/api-without-context/index.ts
@@ -1,3 +1,9 @@
+/**
+ * @module
+ * @deprecated This entrypoint should no longer be used. Use {@link initG}
+ *   instead.
+ */
+import { initG } from "@graphql-ts/schema";
 export {
   arg,
   inputObject,
@@ -32,26 +38,38 @@ import type {
   GType,
 } from "../types";
 
-/** @deprecated Use {@link GEnumType} instead */
+/**
+ * @deprecated Use {@link GEnumType} or {@link enumType `g<typeof g.enum<...>>`}
+ *   instead
+ */
 export type EnumType<Values extends { [key: string]: unknown }> =
   GEnumType<Values>;
-/** @deprecated Use {@link GArg} instead */
+/** @deprecated Use {@link GArg} or {@link arg `g<typeof g.arg<...>>`} instead */
 export type Arg<
   Type extends GInputType,
   HasDefaultValue extends boolean = boolean,
 > = GArg<Type, HasDefaultValue>;
-/** @deprecated Use {@link GList} instead */
+/** @deprecated Use {@link GList} or {@link list `g<typeof g.list<...>>`} instead */
 export type ListType<Of extends GType<any>> = GList<Of>;
-/** @deprecated Use {@link GNonNull} instead */
+/**
+ * @deprecated Use {@link GNonNull} or {@link nonNull `g<typeof g.nonNull<...>>`}
+ *   instead
+ */
 export type NonNullType<Of extends GNullableType<any>> = GNonNull<Of>;
 
-/** @deprecated Use {@link GScalarType} instead */
+/**
+ * @deprecated Use {@link GScalarType} or {@link scalar `g<typeof g.scalar<...>>`}
+ *   instead
+ */
 export type ScalarType<Internal, External = Internal> = GScalarType<
   Internal,
   External
 >;
 
-/** @deprecated Use {@link GInputObjectType} instead */
+/**
+ * @deprecated Use {@link GInputObjectType} or
+ *   {@link inputObject `g<typeof g.inputObject<...>>`} instead
+ */
 export type InputObjectType<
   Fields extends {
     [key: string]: IsOneOf extends true

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -7,16 +7,45 @@
  * [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html).
  *
  * ```ts
- * import { g } from "@graphql-ts/schema";
+ * import { initG } from "@graphql-ts/schema";
  * import { GraphQLSchema, graphql } from "graphql";
+ *
+ * type Context = {
+ *   loadPerson: (id: string) => Person;
+ *   loadFriends: (id: string) => Person[];
+ * };
+ * const g = initG<Context>();
+ * type g<T> = initG<T>;
+ *
+ * type Person = {
+ *   id: string;
+ *   name: string;
+ * };
+ *
+ * const Person: g<typeof g.object<Person>> = g.object<Person>()({
+ *   name: "Person",
+ *   fields: () => ({
+ *     id: g.field({ type: g.ID }),
+ *     name: g.field({ type: g.String }),
+ *     friends: g.field({
+ *       type: g.list(Person),
+ *       resolve(source, _, context) {
+ *         return context.loadFriends(source.id);
+ *       },
+ *     }),
+ *   }),
+ * });
  *
  * const Query = g.object()({
  *   name: "Query",
  *   fields: {
- *     hello: g.field({
- *       type: g.String,
- *       resolve() {
- *         return "Hello!";
+ *     person: g.field({
+ *       type: Person,
+ *       args: {
+ *         id: g.arg({ type: g.ID }),
+ *       },
+ *       resolve(_, args, context) {
+ *         return context.loadPerson(args.id);
  *       },
  *     }),
  *   },
@@ -26,13 +55,37 @@
  *   query: Query,
  * });
  *
+ * const people = new Map<string, Person>([
+ *   ["1", { id: "1", name: "Alice" }],
+ *   ["2", { id: "2", name: "Bob" }],
+ * ]);
+ * const friends = new Map<string, string[]>([
+ *   ["1", ["2"]],
+ *   ["2", ["1"]],
+ * ]);
+ *
  * graphql({
  *   source: `
- *     query {
- *       hello
- *     }
- *   `,
+ *       query {
+ *         person(id: "1") {
+ *           id
+ *           name
+ *           friends {
+ *             id
+ *             name
+ *           }
+ *         }
+ *       }
+ *     `,
  *   schema,
+ *   context: {
+ *     loadPerson: (id) => people.get(id),
+ *     loadFriends: (id) => {
+ *       return (friends.get(id) ?? [])
+ *         .map((id) => people.get(id))
+ *         .filter((person) => person !== undefined);
+ *     },
+ *   },
  * }).then((result) => {
  *   console.log(result);
  * });
@@ -40,8 +93,9 @@
  *
  * @module
  */
-export * as g from "./schema-api";
-export { initG, type GWithContext } from "./output";
+import { initG, type GWithContext } from "./output";
+export { initG };
+export type { GWithContext };
 
 export {
   GObjectType,
@@ -67,6 +121,8 @@ export {
   type InferValueFromArgs,
   type InferValueFromInputType,
 } from "./types";
+export { g } from "./schema-api";
+
 export type {
   Arg,
   EnumType,

--- a/packages/schema/src/schema-api-alias.d.ts
+++ b/packages/schema/src/schema-api-alias.d.ts
@@ -1,4 +1,4 @@
-import * as _graphql from "./schema-api";
+import { g as _graphql } from "./schema-api";
 
 /**
  * The `graphql` export has been renamed to `g`.

--- a/packages/schema/src/schema-api-alias.js
+++ b/packages/schema/src/schema-api-alias.js
@@ -1,1 +1,1 @@
-export * as graphql from "./schema-api";
+export { g as graphql } from "./schema-api";

--- a/packages/schema/src/schema-api.ts
+++ b/packages/schema/src/schema-api.ts
@@ -1,232 +1,155 @@
-/**
- * The `g` export is the primary entrypoint into `@graphql-ts/schema` that lets
- * you compose GraphQL types into a GraphQL Schema
- *
- * A simple schema with only a query type looks like this.
- *
- * ```ts
- * import { g } from "@graphql-ts/schema";
- * import { GraphQLSchema, graphql } from "graphql";
- *
- * const Query = g.object()({
- *   name: "Query",
- *   fields: {
- *     hello: g.field({
- *       type: g.String,
- *       resolve() {
- *         return "Hello!";
- *       },
- *     }),
- *   },
- * });
- *
- * const schema = new GraphQLSchema({
- *   query: Query,
- * });
- *
- * graphql({
- *   source: `
- *     query {
- *       hello
- *     }
- *   `,
- *   schema,
- * }).then((result) => {
- *   console.log(result);
- * });
- * ```
- *
- * You can use pass the `graphQLSchema` to `ApolloServer` and other GraphQL
- * servers.
- *
- * You can also create a more advanced schema with other object types, args and
- * mutations.
- *
- * ```ts
- * import { g } from "@graphql-ts/schema";
- * import { GraphQLSchema, graphql } from "graphql";
- * import { deepEqual } from "assert";
- *
- * type TodoItem = {
- *   title: string;
- * };
- *
- * const todos: TodoItem[] = [];
- *
- * const Todo = g.object<TodoItem>({
- *   name: "Todo",
- *   fields: {
- *     title: g.field({ type: g.String }),
- *   },
- * });
- *
- * const Query = g.object()({
- *   name: "Query",
- *   fields: {
- *     todos: g.field({
- *       type: g.list(Todo),
- *       resolve() {
- *         return todos;
- *       },
- *     }),
- *   },
- * });
- *
- * const Mutation = g.object()({
- *   name: "Mutation",
- *   fields: {
- *     createTodo: g.field({
- *       args: {
- *         title: g.arg({ type: g.String }),
- *       },
- *       type: Todo,
- *       resolve(source, { title }) {
- *         const todo = { title };
- *         todos.push(todo);
- *         return todo;
- *       },
- *     }),
- *   },
- * });
- *
- * const schema = new GraphQLSchema({
- *   query: Query,
- *   mutation: Mutation,
- * });
- *
- * (async () => {
- *   const result = await graphql({
- *     source: `
- *       query {
- *         todos {
- *           title
- *         }
- *       }
- *     `,
- *     schema,
- *   });
- *   deepEqual(result, { data: { todos: [] } });
- *
- *   const result = await graphql({
- *     source: `
- *       mutation {
- *         createTodo(title: "Try @graphql-ts/schema") {
- *           title
- *         }
- *       }
- *     `,
- *     schema,
- *   });
- *   deepEqual(result, {
- *     data: { createTodo: { title: "Try @graphql-ts/schema" } },
- *   });
- *
- *   const result = await graphql({
- *     source: `
- *       query {
- *         todos {
- *           title
- *         }
- *       }
- *     `,
- *     schema,
- *   });
- *   deepEqual(result, {
- *     data: { todos: [{ title: "Try @graphql-ts/schema" }] },
- *   });
- * })();
- * ```
- *
- * For information on how to construct other types like input objects, unions,
- * interfaces and enums and more detailed information, see the documentation in
- * the `g` export below.
- *
- * When using it, you're going to want to create your own version of it bound to
- * your specific `Context` type.
- *
- * @module
- */
-export { field, object } from "./api-with-context";
-export {
-  arg,
-  Boolean,
-  Float,
-  ID,
-  Int,
-  String,
-  inputObject,
-  list,
-  nonNull,
-  enum,
-  enumValues,
-} from "./api-without-context";
-export { fields, interface, interfaceField, union } from "./api-with-context";
-export type {
-  InferValueFromArg,
-  InferValueFromArgs,
-  InferValueFromInputType,
-  InferValueFromOutputType,
-  InputObjectType,
-  InputType,
-  ListType,
-  NonNullType,
-  NullableInputType,
-  ScalarType,
-  EnumType,
-  Arg,
-} from "./api-without-context";
-export { scalar } from "./api-without-context";
 import type {
   GArg,
+  GEnumType,
   GField,
   GFieldResolver,
+  GInputObjectType,
   GInputType,
   GInterfaceField,
   GInterfaceType,
+  GList,
+  GNonNull,
+  GNullableInputType,
   GNullableOutputType,
   GNullableType,
   GObjectType,
   GOutputType,
+  GScalarType,
   GType,
   GUnionType,
+  InferValueFromInputType as _InferValueFromInputType,
+  InferValueFromArgs as _InferValueFromArgs,
+  InferValueFromOutputType as _InferValueFromOutputType,
+  InferValueFromArg as _InferValueFromArg,
 } from "./types";
 
-/**
- * The particular `Context` type for this `graphql` export that is provided to
- * field resolvers.
- *
- * Below, there are many types exported which are similar to the types with the
- * same names exported from the root of the package except that they are bound
- * to the `Context` type so they can be used elsewhere without needing to be
- * bound to the context on every usage.
- */
-export type Context = unknown;
+import { initG } from "./output";
 
-export type NullableType = GNullableType<Context>;
-export type Type = GType<Context>;
-export type NullableOutputType = GNullableOutputType<Context>;
-export type OutputType = GOutputType<Context>;
-export type Field<
-  Source,
-  Args extends Record<string, GArg<GInputType>>,
-  TType extends OutputType,
-  SourceAtKey,
-> = GField<Source, Args, TType, SourceAtKey, Context>;
-export type FieldResolver<
-  Source,
-  Args extends Record<string, GArg<GInputType>>,
-  TType extends OutputType,
-> = GFieldResolver<Source, Args, TType, Context>;
-export type ObjectType<Source> = GObjectType<Source, Context>;
-export type UnionType<Source> = GUnionType<Source, Context>;
-export type InterfaceType<
-  Source,
-  Fields extends Record<
-    string,
-    GInterfaceField<Record<string, GArg<GInputType>>, OutputType, Context>
-  >,
-> = GInterfaceType<Source, Fields, Context>;
-export type InterfaceField<
-  Args extends Record<string, GArg<GInputType>>,
-  TType extends OutputType,
-> = GInterfaceField<Args, TType, Context>;
+/**
+ * @deprecated Use {@link initG} to bind `g` to a specific context instead of
+ *   this generic `g`
+ */
+export const g = initG<g.Context>();
+export type g<T> = initG<T>;
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export declare namespace g {
+  export type Context = unknown;
+  /**
+   * @deprecated Use {@link GEnumType} or {@link g.enum `g<typeof g.enum<...>>`}
+   *   instead
+   */
+  export type EnumType<Values extends { [key: string]: unknown }> =
+    GEnumType<Values>;
+  /** @deprecated Use {@link GArg} or {@link g.arg `g<typeof g.arg<...>>`} instead */
+  export type Arg<
+    Type extends GInputType,
+    HasDefaultValue extends boolean = boolean,
+  > = GArg<Type, HasDefaultValue>;
+  /**
+   * @deprecated Use {@link GList} or {@link g.list `g<typeof g.list<...>>`}
+   *   instead
+   */
+  export type ListType<Of extends GType<any>> = GList<Of>;
+  /**
+   * @deprecated Use {@link GNonNull} or
+   *   {@link g.nonNull `g<typeof g.nonNull<...>>`} instead
+   */
+  export type NonNullType<Of extends GNullableType<any>> = GNonNull<Of>;
+
+  /**
+   * @deprecated Use {@link GScalarType} or
+   *   {@link g.scalar `g<typeof g.scalar<...>>`} instead
+   */
+  export type ScalarType<Internal, External = Internal> = GScalarType<
+    Internal,
+    External
+  >;
+
+  /**
+   * @deprecated Use {@link GInputObjectType} or
+   *   {@link g.inputObject `g<typeof g.inputObject<...>>`} instead
+   */
+  export type InputObjectType<
+    Fields extends {
+      [key: string]: IsOneOf extends true
+        ? GArg<GNullableInputType, false>
+        : GArg<GInputType>;
+    },
+    IsOneOf extends boolean = false,
+  > = GInputObjectType<Fields, IsOneOf>;
+  /** @deprecated Use {@link GNullableInputType} instead */
+  export type NullableInputType = GNullableInputType;
+  /** @deprecated Use {@link GInputType} instead */
+  export type InputType = GInputType;
+
+  /** @deprecated Use {@link GNullableType} instead. */
+  export type NullableType = GNullableType<Context>;
+  /** @deprecated Use {@link GType} instead. */
+  export type Type = GType<Context>;
+  /** @deprecated Use {@link GNullableOutputType} instead. */
+  export type NullableOutputType = GNullableOutputType<Context>;
+  /** @deprecated Use {@link GOutputType} instead. */
+  export type OutputType = GOutputType<Context>;
+  /** @deprecated Use {@link GField} instead. */
+  export type Field<
+    Source,
+    Args extends Record<string, GArg<GInputType>>,
+    TType extends GOutputType<Context>,
+    SourceAtKey,
+  > = GField<Source, Args, TType, SourceAtKey, Context>;
+  /** @deprecated Use {@link GFieldResolver} instead. */
+  export type FieldResolver<
+    Source,
+    Args extends Record<string, GArg<GInputType>>,
+    TType extends GOutputType<Context>,
+  > = GFieldResolver<Source, Args, TType, Context>;
+  /**
+   * @deprecated Use {@link GObjectType} or
+   *   {@link object `g<typeof g.object<...>`} instead.
+   */
+  export type ObjectType<Source> = GObjectType<Source, Context>;
+  /**
+   * @deprecated Use {@link GUnionType} or {@link g.union `g<typeof g.union<...>`}
+   *   instead.
+   */
+  export type UnionType<Source> = GUnionType<Source, Context>;
+  /** @deprecated Use {@link GInterfaceType} instead. */
+  export type InterfaceType<
+    Source,
+    Fields extends Record<
+      string,
+      GInterfaceField<Record<string, GArg<GInputType>>, OutputType, Context>
+    >,
+  > = GInterfaceType<Source, Fields, Context>;
+  /**
+   * @deprecated Use {@link GInterfaceField} or
+   *   {@link g.interfaceField `g<typeof g.interfaceField<...>`} instead.
+   */
+  export type InterfaceField<
+    Args extends Record<string, GArg<GInputType>>,
+    TType extends GOutputType<Context>,
+  > = GInterfaceField<Args, TType, Context>;
+
+  /** @deprecated Use {@link _InferValueFromArg `InferValueFromArg`} instead. */
+  export type InferValueFromArg<Arg extends GArg<GInputType>> =
+    _InferValueFromArg<Arg>;
+
+  /** @deprecated Use {@link _InferValueFromArgs `InferValueFromArgs`} instead. */
+  export type InferValueFromArgs<Arg extends Record<string, GArg<GInputType>>> =
+    _InferValueFromArgs<Arg>;
+
+  /**
+   * @deprecated Use {@link _InferValueFromInputType `InferValueFromInputType`}
+   *   instead.
+   */
+  export type InferValueFromInputType<InputType extends GInputType> =
+    _InferValueFromInputType<InputType>;
+
+  /**
+   * @deprecated Use {@link _InferValueFromOutputType `InferValueFromOutputType`}
+   *   instead.
+   */
+  export type InferValueFromOutputType<OutputType extends GOutputType<any>> =
+    _InferValueFromOutputType<OutputType>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@graphql-ts/schema':
         specifier: workspace:^
         version: link:../packages/schema
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.13.10
       graphql:
         specifier: ^16.3.0
         version: 16.10.0
@@ -976,8 +979,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.10.10':
-    resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
+  '@types/node@22.13.10':
+    resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
 
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
@@ -3775,7 +3778,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -3788,7 +3791,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -3822,14 +3825,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       jest-mock: 27.5.1
 
   '@jest/fake-timers@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -3847,7 +3850,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3916,7 +3919,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -3924,7 +3927,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -4154,7 +4157,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -4181,7 +4184,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.10.10':
+  '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
 
@@ -4189,7 +4192,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
 
   '@types/stack-utils@2.0.3': {}
 
@@ -5058,7 +5061,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -5161,7 +5164,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -5176,7 +5179,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -5188,7 +5191,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5207,7 +5210,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -5250,7 +5253,7 @@ snapshots:
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
 
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
@@ -5286,7 +5289,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -5337,7 +5340,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
@@ -5370,7 +5373,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -5389,7 +5392,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -5397,13 +5400,13 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 22.13.10
       merge-stream: 2.0.0
       supports-color: 8.1.1
 

--- a/test-project/example-2.ts
+++ b/test-project/example-2.ts
@@ -1,0 +1,122 @@
+/// <reference types="node" />
+import { initG } from "@graphql-ts/schema";
+import { GraphQLSchema, graphql } from "graphql";
+import { deepEqual } from "node:assert";
+
+type Context = {
+  todos: Map<string, TodoItem>;
+};
+
+const g = initG<Context>();
+type g<T> = initG<T>;
+
+type TodoItem = {
+  id: string;
+  title: string;
+  relatedTodos: string[];
+};
+
+const Todo: g<typeof g.object<TodoItem>> = g.object<TodoItem>()({
+  name: "Todo",
+  fields: () => ({
+    id: g.field({ type: g.nonNull(g.ID) }),
+    title: g.field({ type: g.nonNull(g.String) }),
+    relatedTodos: g.field({
+      type: g.list(Todo),
+      resolve(source, _args, context) {
+        return source.relatedTodos
+          .map((id) => context.todos.get(id))
+          .filter((todo) => todo !== undefined);
+      },
+    }),
+  }),
+});
+
+const Query = g.object()({
+  name: "Query",
+  fields: {
+    todos: g.field({
+      type: g.list(Todo),
+      resolve(_source, _args, context) {
+        return context.todos.values();
+      },
+    }),
+  },
+});
+
+const Mutation = g.object()({
+  name: "Mutation",
+  fields: {
+    createTodo: g.field({
+      args: {
+        title: g.arg({ type: g.nonNull(g.String) }),
+        relatedTodos: g.arg({
+          type: g.nonNull(g.list(g.nonNull(g.ID))),
+          defaultValue: [],
+        }),
+      },
+      type: Todo,
+      resolve(_source, { title, relatedTodos }, context) {
+        const todo = { title, relatedTodos, id: crypto.randomUUID() };
+        context.todos.set(todo.id, todo);
+        return todo;
+      },
+    }),
+  },
+});
+
+const schema = new GraphQLSchema({
+  query: Query,
+  mutation: Mutation,
+});
+
+(async () => {
+  const contextValue: Context = { todos: new Map() };
+  {
+    const result = await graphql({
+      source: `
+        query {
+          todos {
+            title
+          }
+        }
+      `,
+      schema,
+      contextValue,
+    });
+    deepEqual(result, { data: { todos: [] } });
+  }
+
+  {
+    const result = await graphql({
+      source: `
+        mutation {
+          createTodo(title: "Try graphql-ts") {
+            title
+          }
+        }
+      `,
+      schema,
+      contextValue,
+    });
+    deepEqual(result, {
+      data: { createTodo: { title: "Try graphql-ts" } },
+    });
+  }
+  {
+    const result = await graphql({
+      source: `
+        query {
+          todos {
+            title
+          }
+        }
+      `,
+      schema,
+      contextValue,
+    });
+    deepEqual(result, {
+      data: { todos: [{ title: "Try graphql-ts" }] },
+    });
+  }
+})();

--- a/test-project/example.ts
+++ b/test-project/example.ts
@@ -1,0 +1,84 @@
+import { initG } from "@graphql-ts/schema";
+import { GraphQLSchema, graphql } from "graphql";
+
+type Context = {
+  loadPerson: (id: string) => Person | undefined;
+  loadFriends: (id: string) => Person[];
+};
+const g = initG<Context>();
+type g<T> = initG<T>;
+
+type Person = {
+  id: string;
+  name: string;
+};
+
+const Person: g<typeof g.object<Person>> = g.object<Person>()({
+  name: "Person",
+  fields: () => ({
+    id: g.field({ type: g.nonNull(g.ID) }),
+    name: g.field({ type: g.nonNull(g.String) }),
+    friends: g.field({
+      type: g.list(g.nonNull(Person)),
+      resolve(source, _, context) {
+        return context.loadFriends(source.id);
+      },
+    }),
+  }),
+});
+
+const Query = g.object()({
+  name: "Query",
+  fields: {
+    person: g.field({
+      type: Person,
+      args: {
+        id: g.arg({ type: g.nonNull(g.ID) }),
+      },
+      resolve(_, args, context) {
+        return context.loadPerson(args.id);
+      },
+    }),
+  },
+});
+
+const schema = new GraphQLSchema({
+  query: Query,
+});
+
+{
+  const people = new Map<string, Person>([
+    ["1", { id: "1", name: "Alice" }],
+    ["2", { id: "2", name: "Bob" }],
+  ]);
+  const friends = new Map<string, string[]>([
+    ["1", ["2"]],
+    ["2", ["1"]],
+  ]);
+  const contextValue: Context = {
+    loadPerson: (id) => people.get(id),
+    loadFriends: (id) => {
+      return (friends.get(id) ?? [])
+        .map((id) => people.get(id))
+        .filter((person) => person !== undefined) as Person[];
+    },
+  };
+  graphql({
+    source: `
+      query {
+        person(id: "1") {
+          id
+          name
+          friends {
+            id
+            name
+          }
+        }
+      }
+    `,
+    schema,
+    contextValue,
+  }).then((result) => {
+    console.log(result);
+  });
+}

--- a/test-project/index.test-d.ts
+++ b/test-project/index.test-d.ts
@@ -2069,3 +2069,86 @@ const someInputFields = {
     Invariant<typeof a>
   >();
 }
+
+{
+  type Person = {
+    name: string;
+  };
+  const Person: g<typeof g.object<Person>> = g.object<Person>()({
+    name: "Person",
+    fields: () => ({
+      name: g.field({ type: g.String }),
+      friends: g.field({
+        type: g.list(Person),
+        resolve() {
+          return [];
+        },
+      }),
+    }),
+  });
+}
+
+{
+  type Context = { loadFriends: (id: string) => Promise<Person[]> };
+  const g = initG<Context>();
+  type g<T> = initG<T>;
+
+  type Person = {
+    id: string;
+    name: string;
+  };
+
+  const Person: g<typeof g.object<Person>> = g.object<Person>()({
+    name: "Person",
+    fields: () => ({
+      id: g.field({ type: g.ID }),
+      name: g.field({ type: g.String }),
+      friends: g.field({
+        type: g.list(Person),
+        resolve(source, _, context) {
+          return context.loadFriends(source.id);
+        },
+      }),
+    }),
+  });
+}
+
+{
+  type Context = {};
+  const g = initG<Context>();
+  type g<T> = initG<T>;
+
+  type PersonFilter = GInputObjectType<{
+    name: g<typeof g.arg<typeof g.String>>;
+    friends: g<typeof g.arg<PersonFilter>>;
+  }>;
+
+  const PersonFilter: PersonFilter = g.inputObject({
+    name: "PersonFilter",
+    fields: () => ({
+      name: g.arg({ type: g.String }),
+      friends: g.arg({ type: PersonFilter }),
+    }),
+  });
+}
+
+{
+  type Context = {};
+  const g = initG<Context>();
+  type g<T> = initG<T>;
+
+  const Node: g<typeof g.interface<{ id: string }>> = g.interface<{
+    id: string;
+  }>()({
+    name: "Node",
+    fields: () => ({
+      id: g.field({ type: g.ID }),
+      relatedNodes: g.field({
+        type: g.list(Node),
+        resolve() {
+          return [];
+        },
+      }),
+    }),
+  });
+}

--- a/test-project/package.json
+++ b/test-project/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@graphql-ts/extend": "workspace:^",
     "@graphql-ts/schema": "workspace:^",
+    "@types/node": "^22.13.10",
     "graphql": "^16.3.0"
   }
 }


### PR DESCRIPTION
This is an alternative to #41 attempting to solve the same problem.

Instead of the big type definition of `g`, `g` is defined as "get the return type of the function but if the function takes no arguments and the function returns a function that does take arguments, get the return type of _that_ function". So this can be used with the functions like `g.object` + [instantiation expressions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#instantiation-expressions). This is definitely a much neater design than #40 and nicely has less API going on but it has some problems:

- Defining circular **input** object types does not work (this is the main problem)
- This doesn't include something to easily get the types like `OutputType`/etc. 
- If defining circular input object types did work, the extra `typeof` and `g.` and `<...>` syntax clutter up definitions a lot

While these problems aren't great, I think they're probably the right trade-offs and for cases where `g<typeof g.something<...>>` don't work, people can use the exports from `@graphql-ts/schema` especially since those cases are much more advanced use cases.

Here's the same example as in #41 but using this 

```ts
import { initG } from "@graphql-ts/schema";
import { GraphQLSchema, graphql } from "graphql";

type Context = {
  loadPerson: (id: string) => Person | undefined;
  loadFriends: (id: string) => Person[];
};
const g = initG<Context>();
type g<T> = initG<T>;

type Person = {
  id: string;
  name: string;
};

const Person: g<typeof g.object<Person>> = g.object<Person>()({
  name: "Person",
  fields: () => ({
    id: g.field({ type: g.nonNull(g.ID) }),
    name: g.field({ type: g.nonNull(g.String) }),
    friends: g.field({
      type: g.list(g.nonNull(Person)),
      resolve(source, _, context) {
        return context.loadFriends(source.id);
      },
    }),
  }),
});
```
